### PR TITLE
Add info on running webpage locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ homepage build
 
 Your custom homepage is now available under `public/homepage.html`. 
 
-Tip: run `python3 -m http.server 8000 --directory public` to see your webpage in action on https://localhost:8000.
+Tip: run `python -m http.server 8000 --directory public` to see your webpage in action on https://localhost:8000.
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ Then, modify `settings.yaml` to your liking, and run
 homepage build
 ```
 
-Your custom homepage is now available under `public/homepage.html`.
+Your custom homepage is now available under `public/homepage.html`. 
+
+Tip: run `python3 -m http.server 8000 --directory public` to see your webpage in action on https://localhost:8000.
 
 ## Acknowledgements
 


### PR DESCRIPTION
Added some info to the docs. 

I'm wondering why you are using `homepage.html` instead of `index.html`. That's more elegant, isn't it? I'm now renaming it. 

```bash
mv public/homepage.html public/index.html
python3 -m http.server 8000 --directory public
```

